### PR TITLE
Provide hash function for enum class FairMQ::Transport

### DIFF
--- a/fairmq/FairMQTransports.h
+++ b/fairmq/FairMQTransports.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <unordered_map>
 
+
 namespace FairMQ
 {
 
@@ -31,4 +32,17 @@ static std::unordered_map<std::string, Transport> TransportTypes {
 
 }
 
+namespace std
+{
+
+template <>
+struct hash<FairMQ::Transport>
+{
+    size_t operator()(const FairMQ::Transport& v) const
+    {
+        return hash<int>()(static_cast<int>(v));
+    }
+};
+
+}
 #endif /* FAIRMQTRANSPORTS_H_ */


### PR DESCRIPTION
Without this a build failed on GCC 4.9.2 (Debian 7).